### PR TITLE
Update package.json properties structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "module": "./dist/vue-3-material-date-picker.js",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/vue-3-material-date-picker.js",
       "require": "./dist/vue-3-material-date-picker.umd.cjs"
     },
@@ -31,7 +32,6 @@
       "require": "./dist/style.css"
     }
   },
-  "types": "./dist/index.d.ts",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc && vite build",


### PR DESCRIPTION
The `types` field in package.json is no longer used if there is an `exports` field:

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing

It needs to be properly arranged because if not, it leads to the following issue:

https://stackoverflow.com/questions/76211877/the-xxxx-library-may-need-to-update-its-package-json-or-typings-ts